### PR TITLE
Fix MVC per-view DPB management: add same_views mask

### DIFF
--- a/src/edge264_headers.c
+++ b/src/edge264_headers.c
@@ -1222,13 +1222,13 @@ int ADD_VARIANT(parse_slice_layer_without_partitioning)(Edge264Decoder *dec, Edg
 			for (unsigned o = dec->to_get_frames & ~dec->output_frames & same_views; o; o &= o - 1)
 				max_bump += dec->FieldOrderCnt[0][__builtin_ctz(o)] < dec->TopFieldOrderCnt;
 		}
-		while (__builtin_popcount(reference_frames | dec->to_get_frames & ~dec->output_frames) > sps->max_dec_frame_buffering && max_bump--)
+		while (__builtin_popcount((reference_frames | dec->to_get_frames & ~dec->output_frames) & same_views) > sps->max_dec_frame_buffering && max_bump--)
 			bump_frame(dec, non_base_view, 0);
 		dec->to_get_frames |= 1 << dec->currPic;
 		if (max_bump < 0) {
 			dec->output_frames |= 1 << dec->currPic;
 			dec->get_frame_queue_v[non_base_view] = shrd128(set8(dec->currPic), dec->get_frame_queue_v[non_base_view], 15);
-		} else if (__builtin_popcount(dec->to_get_frames & ~dec->output_frames) > sps->max_num_reorder_frames) {
+		} else if (__builtin_popcount(dec->to_get_frames & ~dec->output_frames & same_views) > sps->max_num_reorder_frames) {
 			bump_frame(dec, non_base_view, 0);
 		}
 		#ifdef LOGS


### PR DESCRIPTION
## Summary

Two DPB management checks in `edge264_headers.c` count pending frames from **both** MVC views against **per-view** SPS limits. This causes incorrect frame bumping and output ordering in MVC streams.

## The Two Bugs (Same Root Cause)

### 1. DPB fullness check (line ~1225)

```c
// Before: counts both views against per-view limit
while (popcount(reference_frames | to_get & ~output) > max_dec_frame_buffering && max_bump--)

// After: counts only current view
while (popcount((reference_frames | to_get & ~output) & same_views) > max_dec_frame_buffering && max_bump--)
```

With both views contributing ~8 frames against a per-view limit of 4, the loop bumps too many frames, driving `max_bump` negative. The `max_bump < 0` path then directly inserts frames into the FIFO output queue, **bypassing `bump_frame()`'s POC-ordered output**. This corrupts the base view's display order.

### 2. Reorder threshold check (line ~1231)

```c
// Before: counts both views against per-view limit
} else if (popcount(to_get & ~output) > max_num_reorder_frames) {

// After: counts only current view
} else if (popcount(to_get & ~output & same_views) > max_num_reorder_frames) {
```

Counting both views' pending frames triggers premature bumping from the current view's queue. Since `edge264_get_frame()` pairs base and dependent views by FIFO queue position, this desynchronizes the two queues, pairing frames from different temporal moments.

## Symptoms

- **Bug 1**: Base view (left eye) frame stutter during playback — frames appear out of display order
- **Bug 2**: Dependent view (right eye) exhibits ±1 frame temporal oscillation in a repeating 6-frame cycle matching the IBBBP GOP substructure

Quantitative analysis of a commercial MVC stream showed ~63% of dependent view frames were temporally displaced by ±1 frame (±42ms at 24fps).

## Verification

- Tested on commercial 3D Blu-ray MVC streams (130,000+ frame pairs, High Profile, CABAC, `max_num_reorder_frames=4`)
- Before fix: periodic right-eye motion spikes (1.4x mean, up to 2.2x) and left-eye POC ordering corruption
- After fix: both views smooth, correct stereo output across entire stream
- 85/85 JVT conformance streams continue to pass

## Note

The `same_views` bitmask is already used correctly in the `max_bump` calculation at line 1222 and in `bump_frame()` itself. These two lines were the only places missing it.